### PR TITLE
Ajout perche mine dans caisse demo (EOD)

### DIFF
--- a/Day01/Core/C/ADF_cCargo_B_Demo.sqf
+++ b/Day01/Core/C/ADF_cCargo_B_Demo.sqf
@@ -49,7 +49,8 @@ if (ADF_mod_ACE3) then {
 	_crate addItemCargoGlobal ["ACE_M26_Clacker",_itm];
 	_crate addItemCargoGlobal ["ACE_DeadManSwitch",_itm];
 	_crate addItemCargoGlobal ["ACE_DefusalKit",_itm];
-	_crate addItemCargoGlobal ["ACE_wirecutter",_itm];	
+	_crate addItemCargoGlobal ["ACE_wirecutter",_itm];
+	_crate addItemCargoGlobal ["ACE_VMH3",_itm];
 };
 
 


### PR DESCRIPTION
Ajout de la poêle à frire (perche détection mine) dans la caisse démo (eod) :

l.53 _crate addItemCargoGlobal ["ACE_VMH3",_itm];